### PR TITLE
Don't use lateinit vars in ForLoopBenchmark

### DIFF
--- a/src/main/kotlin/org/jetbrains/ForLoopBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/ForLoopBenchmark.kt
@@ -10,9 +10,9 @@ import java.util.concurrent.TimeUnit
 @CompilerControl(CompilerControl.Mode.DONT_INLINE)
 open class ForLoopBenchmark: SizedBenchmark() {
     var sizeLong: Long = 0L
-    lateinit var intRange: IntRange
-    lateinit var longRange: LongRange
-    lateinit var array: IntArray
+    var intRange: IntRange = IntRange.EMPTY
+    var longRange: LongRange = LongRange.EMPTY
+    var array: IntArray = IntArray(0)
 
     @Setup
     fun setup() {


### PR DESCRIPTION
Virtual getter calls generated by JVM_IR introduce noise visible on small benchmark instances.

See https://docs.google.com/spreadsheets/d/1AX-de9vhEi4x_UWM-qQiLx8Tx87yBwTZdQBxaPs56H8/edit#gid=387207999, `no lateinit`.