### PR TITLE
Fix StringBenchmark.summarizeSplittedCsv

### DIFF
--- a/src/main/java/org/jetbrains/StringBenchmarkJava.java
+++ b/src/main/java/org/jetbrains/StringBenchmarkJava.java
@@ -22,9 +22,14 @@ public class StringBenchmarkJava extends SizedBenchmark {
         data = list;
         final Random random = new Random(123456789);
         csv = "";
+        boolean p = false;
         for (int i=0; i<getSize(); i++) {
+            if (p) {
+                csv += ",";
+            } else {
+                p = true;
+            }
             csv += random.nextDouble();
-            csv += ",";
         }
     }
 

--- a/src/main/kotlin/org/jetbrains/StringBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/StringBenchmark.kt
@@ -26,10 +26,15 @@ open class StringBenchmark : SizedBenchmark() {
         _data = list
         val random = Random(123456789)
         csv = ""
+        var p = false
         for (i in 1..size) {
+            if (p) {
+                csv += ","
+            } else {
+                p = true
+            }
             val elem = random.nextDouble()
             csv += elem
-            csv += ","
         }
     }
 


### PR DESCRIPTION
Otherwise it fails:
```
java.lang.NumberFormatException: empty String
        at java.base/jdk.internal.math.FloatingDecimal.readJavaFormatString(Unknown Source)
        at java.base/jdk.internal.math.FloatingDecimal.parseDouble(Unknown Source)
        at java.base/java.lang.Double.parseDouble(Unknown Source)
        at org.jetbrains.StringBenchmark.summarizeSplittedCsv(StringBenchmark.kt:75)
```
because in Kotlin `String.split(",")` behaves differently from Java.