### PR TITLE
IntegerVectorizationBenchmark

### DIFF
--- a/src/main/kotlin/org/jetbrains/EulerBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/EulerBenchmark.kt
@@ -3,6 +3,7 @@ package org.jetbrains
 import org.openjdk.jmh.annotations.*
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 fun fibonacci(): Sequence<Int> {
     var a = 0

--- a/src/main/kotlin/org/jetbrains/IntegerVectorBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/IntegerVectorBenchmark.kt
@@ -1,0 +1,84 @@
+package org.jetbrains
+
+import org.openjdk.jmh.annotations.*
+import org.openjdk.jmh.infra.Blackhole
+import java.util.*
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+
+@ExperimentalUnsignedTypes
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@CompilerControl(CompilerControl.Mode.DONT_INLINE)
+open class IntegerVectorBenchmark : VectorSizedBenchmark() {
+    // This benchmarks mostly checks that UInt operations don't get in the way of loop optimizations.
+
+    private var iA = IntArray(0)
+    private var iB = IntArray(0)
+    private var uA = UIntArray(0)
+    private var uB = UIntArray(0)
+
+    @Setup
+    fun setup() {
+        val n = size
+        val random = Random()
+        iA = IntArray(n) { random.nextInt() }
+        iB = IntArray(n) { random.nextInt() }
+        uA = UIntArray(n) { random.nextInt().toUInt() }
+        uB = UIntArray(n) { random.nextInt().toUInt() }
+    }
+
+    @Benchmark
+    fun intVectorAdd(bh: Blackhole) {
+        val iX = IntArray(iA.size)
+        for (i in iA.indices) {
+            iX[i] = iA[i] + iB[i]
+        }
+        bh.consume(iX)
+    }
+
+    @Benchmark
+    fun intVectorSumReduction(bh: Blackhole) {
+        var x = 0
+        for (i in iA.indices) {
+            x += iA[i]
+        }
+        bh.consume(x)
+    }
+
+    @Benchmark
+    fun intVectorMaxReduction(bh: Blackhole) {
+        var x = Int.MIN_VALUE
+        for (i in iA.indices) {
+            x = max(x, iA[i])
+        }
+        bh.consume(x)
+    }
+
+    @Benchmark
+    fun uintVectorAdd(bh: Blackhole) {
+        val uX = UIntArray(uA.size)
+        for (i in uA.indices) {
+            uX[i] = uA[i] + uB[i]
+        }
+        bh.consume(uX)
+    }
+
+    @Benchmark
+    fun uintVectorSumReduction(bh: Blackhole) {
+        var ux = 0U
+        for (i in uA.indices) {
+            ux += uA[i]
+        }
+        bh.consume(ux)
+    }
+
+    @Benchmark
+    fun uintVectorMaxReduction(bh: Blackhole) {
+        var ux = UInt.MIN_VALUE
+        for (i in uA.indices) {
+            ux = max(ux, uA[i])
+        }
+        bh.consume(ux)
+    }
+}

--- a/src/main/kotlin/org/jetbrains/RangeSetBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/RangeSetBenchmark.kt
@@ -27,17 +27,16 @@ private class RangeComparator<T: Comparable<T>>: Comparator<ClosedRange<T>> {
     }
 }
 
-private fun <T: Comparable<T>> min(a: T, b: T) = if (a > b) b else a
-
-internal fun <T: Comparable<T>> max(a: T, b: T) = if (a > b) a else b
-
 private data class InternalRange<T: Comparable<T>>(override val start: T, override val endInclusive: T): ClosedRange<T> {
 
     override fun contains(value: T) = value in start..endInclusive
 }
 
 private fun <T: Comparable<T>> ClosedRange<T>.join(other: ClosedRange<T>): ClosedRange<T>? {
-    return if (this joinable other) InternalRange(min(start, this.start), max(endInclusive, this.endInclusive)) else null
+    return if (this joinable other)
+        InternalRange(minOf(start, this.start), maxOf(endInclusive, this.endInclusive))
+    else
+        null
 }
 
 private class KRangeSet<T: Comparable<T>> {

--- a/src/main/kotlin/org/jetbrains/VectorizationBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/VectorizationBenchmark.kt
@@ -3,6 +3,7 @@ package org.jetbrains
 import org.openjdk.jmh.annotations.*
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.math.max
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -28,6 +29,7 @@ open class VectorizationBenchmark : VectorSizedBenchmark() {
             vP[i] = i % 2 == 0
         }
     }
+
     @Benchmark
     fun vectorAdd(): DoubleArray {
         val n = size
@@ -101,7 +103,7 @@ open class VectorizationBenchmark : VectorSizedBenchmark() {
         val n = size
         var x = Double.NEGATIVE_INFINITY
         for (i in 0 until n) {
-            x = kotlin.math.max(x, vA[i])
+            x = max(x, vA[i])
         }
         return x
     }


### PR DESCRIPTION
1. Add IntegerVectorizationBenchmark. 
On HotSpot, loop optimizations, especially automated vectorization, are known to be very sensitive to bytecode shape. Check that unsigned arithmetic doesn't introduce visible overhead.

2. Use min/max implementations from stdlib.
Previous version had top-level min/max functions which actually worked with `Comparable<T>`. This introduces unnecessary boxing. HotSpot can eliminate that boxing, but we don't need that noise in arithmetic benchmarks. Use 'minOf' / 'maxOf' functions when we actually want a min/max of Comparables.