### PR TITLE
KT-51492 fix benchmark annotations

### DIFF
--- a/src/main/kotlin/org/jetbrains/LoopBenchmark.kt
+++ b/src/main/kotlin/org/jetbrains/LoopBenchmark.kt
@@ -2,12 +2,10 @@ package org.jetbrains
 
 import org.openjdk.jmh.annotations.*
 import org.openjdk.jmh.infra.Blackhole
-import java.util.*
 import java.util.concurrent.TimeUnit
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@CompilerControl(CompilerControl.Mode.DONT_INLINE)
 open class LoopBenchmark : SizedBenchmark() {
     lateinit var arrayList: List<Value>
     lateinit var array: Array<Value>
@@ -21,19 +19,24 @@ open class LoopBenchmark : SizedBenchmark() {
         array = list.toTypedArray()
     }
 
-    @Benchmark fun arrayLoop(bh: Blackhole) {
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    fun arrayLoop(bh: Blackhole) {
         for (x in array) {
             bh.consume(x)
         }
     }
 
-    @Benchmark fun arrayIndexLoop(bh: Blackhole) {
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    fun arrayIndexLoop(bh: Blackhole) {
         for (i in array.indices) {
             bh.consume(array[i])
         }
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     fun arrayListIndexLoop(bh: Blackhole) {
         for (i in arrayList.indices) {
             bh.consume(array[i])
@@ -41,6 +44,7 @@ open class LoopBenchmark : SizedBenchmark() {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     fun arrayListLoop(bh: Blackhole) {
         for (x in arrayList) {
             bh.consume(x)
@@ -48,6 +52,7 @@ open class LoopBenchmark : SizedBenchmark() {
     }
 
     @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     fun arrayWhileLoop(bh: Blackhole) {
         var i = 0
         val s = array.size
@@ -57,11 +62,15 @@ open class LoopBenchmark : SizedBenchmark() {
         }
     }
 
-    @Benchmark fun arrayForeachLoop(bh: Blackhole) {
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    fun arrayForeachLoop(bh: Blackhole) {
         array.forEach { bh.consume(it) }
     }
 
-    @Benchmark fun arrayListForeachLoop(bh: Blackhole) {
+    @Benchmark
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    fun arrayListForeachLoop(bh: Blackhole) {
         arrayList.forEach { bh.consume(it) }
     }
 }


### PR DESCRIPTION
Before:
```
Benchmark                     (size)  Mode  Cnt       Score       Error  Units
LoopBenchmark.arrayIndexLoop      10  avgt    5      74,313 ?     0,496  ns/op
LoopBenchmark.arrayIndexLoop    1000  avgt    5    6947,446 ?    60,806  ns/op
LoopBenchmark.arrayIndexLoop  100000  avgt    5  694597,949 ? 10135,009  ns/op
```

After:
```
Benchmark                     (size)  Mode  Cnt       Score      Error  Units
LoopBenchmark.arrayIndexLoop      10  avgt    5      41,933 ?    0,425  ns/op
LoopBenchmark.arrayIndexLoop    1000  avgt    5    3851,127 ?   51,661  ns/op
LoopBenchmark.arrayIndexLoop  100000  avgt    5  408370,300 ? 2858,830  ns/op
```